### PR TITLE
feat: adapt to Scrapbox users API

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -44,13 +44,15 @@ func doFetch(cmd *cobra.Command) {
 	latest, _ := cmd.PersistentFlags().GetBool("latest")
 	projectName := config.CurrentProject
 	CheckProject(projectName)
+	projectUsers, err := fetchProjectUsers(projectName)
+	CheckErr(err)
 	if latest {
-		fetchLatestList(api.Limit, projectName)
+		fetchLatestList(api.Limit, projectName, projectUsers)
 	} else {
 		project, err := fetchIndex(projectName)
 		CheckErr(err)
 		fmt.Printf("fetch all pages, %s : %d\n", project.Name, project.Count)
-		err = fetchPageList(project)
+		err = fetchPageList(project, projectUsers)
 		CheckErr(err)
 		groups, err := dividePagesList(3, projectName)
 		CheckErr(err)
@@ -60,7 +62,7 @@ func doFetch(cmd *cobra.Command) {
 		start := time.Now()
 		wg.Add(len(groups))
 		for _, pages := range groups {
-			go fetchPagesByGroup(projectName, pages, &wg)
+			go fetchPagesByGroup(projectName, pages, projectUsers, &wg)
 		}
 		wg.Wait()
 		elapsed := time.Since(start)
@@ -68,15 +70,34 @@ func doFetch(cmd *cobra.Command) {
 	}
 }
 
-func fetchLatestList(num int, projectName string) {
+func fetchLatestList(num int, projectName string, projectUsers map[string]types.User) {
 	fmt.Printf("fetch top %d of %s\n", num, projectName)
 	path := fmt.Sprintf("%s/%s", config.WorkDir, projectName)
 	file.CreateDir(path)
 	var proj types.Project
 	proj.Name = projectName
 	proj.Count = num
-	err := fetchPageList(proj)
+	err := fetchPageList(proj, projectUsers)
 	CheckErr(err)
+}
+
+func fetchProjectUsers(projectName string) (map[string]types.User, error) {
+	data, err := api.FetchProjectUsers(projectName)
+	if err != nil {
+		return nil, err
+	}
+	var projectUsers types.ProjectUsers
+	if err := json.Unmarshal(data, &projectUsers); err != nil {
+		return nil, err
+	}
+	users := map[string]types.User{}
+	for _, user := range projectUsers.Users {
+		if user.DisplayName == "" {
+			user.DisplayName = user.Name
+		}
+		users[user.ID] = user
+	}
+	return users, nil
 }
 
 func fetchIndex(projectName string) (types.Project, error) {
@@ -92,7 +113,7 @@ func fetchIndex(projectName string) (types.Project, error) {
 	return project, nil
 }
 
-func fetchPageList(project types.Project) error {
+func fetchPageList(project types.Project, projectUsers map[string]types.User) error {
 	pages := []types.Page{}
 	for skip := 0; skip < project.Count; skip += api.Limit {
 		data, err := api.FetchPageList(project.Name, skip)
@@ -105,6 +126,7 @@ func fetchPageList(project types.Project) error {
 			return err
 		}
 		for _, page := range proj.Pages {
+			enrichPageUsers(&page, projectUsers)
 			pages = append(pages, page)
 		}
 	}
@@ -127,6 +149,19 @@ func fetchPageList(project types.Project) error {
 		return err
 	}
 	return nil
+}
+
+func enrichPageUsers(page *types.Page, projectUsers map[string]types.User) {
+	if user, ok := projectUsers[page.Author.ID]; ok {
+		page.Author.Name = user.Name
+		page.Author.DisplayName = user.DisplayName
+	}
+	for idx, collaborator := range page.Collaborators {
+		if user, ok := projectUsers[collaborator.ID]; ok {
+			page.Collaborators[idx].Name = user.Name
+			page.Collaborators[idx].DisplayName = user.DisplayName
+		}
+	}
 }
 
 func readContrib() (map[string]types.Contribution, error) {
@@ -168,19 +203,28 @@ func dividePagesList(multiplicity int, projectName string) ([][]types.Page, erro
 	return divided, nil
 }
 
-func fetchPagesByGroup(projectName string, pages []types.Page, wg *sync.WaitGroup) error {
+func fetchPagesByGroup(projectName string, pages []types.Page, projectUsers map[string]types.User, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	for _, page := range pages {
 		fmt.Println(page.Title)
-		if err := fetchPage(projectName, page.Title, page.ID); err != nil {
+		if err := fetchPage(projectName, page.Title, page.ID, projectUsers); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func fetchPage(projectName string, title string, index string) error {
+func fetchPage(projectName string, title string, index string, projectUsers map[string]types.User) error {
 	data, err := api.FetchPage(projectName, title)
+	if err != nil {
+		return err
+	}
+	var page types.Page
+	if err := json.Unmarshal(data, &page); err != nil {
+		return err
+	}
+	enrichPageUsers(&page, projectUsers)
+	data, err = json.Marshal(page)
 	if err != nil {
 		return err
 	}

--- a/cmd/fetch_test.go
+++ b/cmd/fetch_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/mamezou-tech/sbgraph/pkg/types"
+)
+
+func TestEnrichPageUsers(t *testing.T) {
+	page := types.Page{
+		Author: types.User{ID: "author-id"},
+		Collaborators: []types.User{
+			{ID: "collab-id"},
+		},
+	}
+	projectUsers := map[string]types.User{
+		"author-id": {
+			ID:          "author-id",
+			Name:        "author-name",
+			DisplayName: "author-display",
+		},
+		"collab-id": {
+			ID:          "collab-id",
+			Name:        "collab-name",
+			DisplayName: "collab-display",
+		},
+	}
+
+	enrichPageUsers(&page, projectUsers)
+
+	if page.Author.Name != "author-name" || page.Author.DisplayName != "author-display" {
+		t.Fatalf("author was not enriched: %#v", page.Author)
+	}
+	if len(page.Collaborators) != 1 {
+		t.Fatalf("unexpected collaborators: %#v", page.Collaborators)
+	}
+	if page.Collaborators[0].Name != "collab-name" || page.Collaborators[0].DisplayName != "collab-display" {
+		t.Fatalf("collaborator was not enriched: %#v", page.Collaborators[0])
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mamezou-tech/sbgraph/pkg/file"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // initCmd represents the init command
@@ -31,4 +32,6 @@ func doInit(cmd *cobra.Command) {
 	fmt.Printf("Check and create workdir : %s\n", config.WorkDir)
 	err := file.CreateDir(config.WorkDir)
 	CheckErr(err)
+	viper.Set("workdir", config.WorkDir)
+	SaveConfig()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,8 @@ func init() {
 	rootCmd.PersistentFlags().StringP("currentproject", "c", "", "current project")
 	viper.BindPFlag("workdir", rootCmd.PersistentFlags().Lookup("workdir"))
 	viper.BindPFlag("currentproject", rootCmd.PersistentFlags().Lookup("currentproject"))
-	config.WorkDir = wkdir
+	viper.SetDefault("workdir", wkdir)
+	syncConfigFromViper()
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -69,6 +70,12 @@ func initConfig() {
 			CheckErr(err)
 		}
 	}
+	syncConfigFromViper()
+}
+
+func syncConfigFromViper() {
+	config.WorkDir = viper.GetString("workdir")
+	config.CurrentProject = viper.GetString("currentproject")
 }
 
 func getConfigPath() string {
@@ -90,5 +97,6 @@ func SaveConfig() {
 		err := viper.Unmarshal(&config)
 		CheckErr(err)
 	}
+	syncConfigFromViper()
 	fmt.Printf("config update: %#v\n", config)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -13,6 +13,7 @@ import (
 const Limit int = 100
 
 const baseURL string = "https://scrapbox.io/api/pages"
+const projectBaseURL string = "https://scrapbox.io/api/projects"
 
 // FetchPageList will fetch page list in the Scrapbox project
 func FetchPageList(projectName string, skip int) ([]byte, error) {
@@ -29,6 +30,12 @@ func FetchPage(projectName string, title string) ([]byte, error) {
 // FetchIndex will fetch index of the Scrapbox project
 func FetchIndex(projectName string) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s?limit=1", baseURL, projectName)
+	return fetch(url)
+}
+
+// FetchProjectUsers will fetch project user list of the Scrapbox project.
+func FetchProjectUsers(projectName string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/users", projectBaseURL, projectName)
 	return fetch(url)
 }
 

--- a/pkg/types/page.go
+++ b/pkg/types/page.go
@@ -16,7 +16,7 @@ type Page struct {
 	Views         int      `json:"views"`
 	Linked        int      `json:"linked"`
 	Author        User     `json:"user"`
-	Collaborators []User   `json:"collaborators"`
+	Collaborators []User   `json:"users"`
 	Image         string   `json:"image"`
 	Tags          []string `json:"links"`
 	Lines         []struct {
@@ -32,6 +32,25 @@ type Page struct {
 			Title string `json:"title"`
 		} `json:"links1hop"`
 	} `json:"relatedPages"`
+}
+
+// UnmarshalJSON keeps backward compatibility with the older collaborators field
+// while preferring the current users field returned by Scrapbox APIs.
+func (page *Page) UnmarshalJSON(data []byte) error {
+	type alias Page
+	aux := struct {
+		Collaborators []User `json:"collaborators"`
+		*alias
+	}{
+		alias: (*alias)(page),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(page.Collaborators) == 0 && len(aux.Collaborators) > 0 {
+		page.Collaborators = aux.Collaborators
+	}
+	return nil
 }
 
 // User represents a Scrapbox user
@@ -50,6 +69,11 @@ type Contribution struct {
 	PagesContributed  int    `json:"pagesContributed"`
 	ViewsCreatedPages int    `json:"viewsCreatedPages"`
 	LinksCreatedPages int    `json:"linksCreatedPages"`
+}
+
+// ProjectUsers represents project users returned by the Scrapbox project API.
+type ProjectUsers struct {
+	Users []User `json:"users"`
 }
 
 // ReadFrom will deserialize Project from file

--- a/pkg/types/page_test.go
+++ b/pkg/types/page_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPageUnmarshalJSONSupportsLegacyCollaborators(t *testing.T) {
+	data := []byte(`{"id":"page-id","title":"Page","user":{"id":"author-id"},"collaborators":[{"id":"collab-id","name":"collab-name"}]}`)
+
+	var page Page
+	if err := json.Unmarshal(data, &page); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if len(page.Collaborators) != 1 {
+		t.Fatalf("len(page.Collaborators) = %d, want 1", len(page.Collaborators))
+	}
+	if page.Collaborators[0].ID != "collab-id" {
+		t.Fatalf("page.Collaborators[0].ID = %q, want %q", page.Collaborators[0].ID, "collab-id")
+	}
+}


### PR DESCRIPTION
## Purpose
- Adapt to recent Scrapbox API response changes around user/collaborator fields.
- Fix workdir persistence so `init` with `-d` updates config reliably.

## Changes
- Added project users API fetch: `/api/projects/:project/users`.
- Switched page collaborator mapping to current `users` field with backward compatibility for legacy `collaborators`.
- Enriched author/collaborator names during fetch using project users.
- Persisted `workdir` in config during `init`.
- Synced config values from Viper to runtime config to honor flag/config precedence.
- Added tests for user enrichment and legacy collaborators unmarshalling.

## Validation
- `go test ./...` passed.
- `go build ./...` passed.
- Manual verification with `help-jp`: fetch/extract outputs include user id + name in authors.

## Impact
- Affects fetch/extract/aggregate user display consistency.
- Improves reliability of workdir behavior across runs.
